### PR TITLE
Salvando posição nos vídeos

### DIFF
--- a/CocoaheadsConf.xcodeproj/project.pbxproj
+++ b/CocoaheadsConf.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		DD3A5AEA1DE60D580016882D /* VideosScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3A5AE91DE60D580016882D /* VideosScene.swift */; };
 		DD3A5AEF1DE60E130016882D /* VideosViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3A5AEE1DE60E130016882D /* VideosViewController.swift */; };
 		DD3A5B141DE633500016882D /* PlaybackHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3A5B131DE633500016882D /* PlaybackHelper.swift */; };
+		DDABFB111DE72AEC00351DA8 /* UserDefaults+CHConf.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDABFB101DE72AEC00351DA8 /* UserDefaults+CHConf.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -216,6 +217,7 @@
 		DD3A5AE91DE60D580016882D /* VideosScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideosScene.swift; sourceTree = "<group>"; };
 		DD3A5AEE1DE60E130016882D /* VideosViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideosViewController.swift; sourceTree = "<group>"; };
 		DD3A5B131DE633500016882D /* PlaybackHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaybackHelper.swift; sourceTree = "<group>"; };
+		DDABFB101DE72AEC00351DA8 /* UserDefaults+CHConf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDefaults+CHConf.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -317,6 +319,7 @@
 				15D88FD81DD34F630055F781 /* Date+Extensions.swift */,
 				1515D1221DDCEF11008690FD /* UIColor+Hex.swift */,
 				15256C211DE6A1EA00263E92 /* String+Capitalize.swift */,
+				DDABFB101DE72AEC00351DA8 /* UserDefaults+CHConf.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -906,6 +909,7 @@
 				152F38D31DCD0C6B00FE9ECF /* MainTabController.swift in Sources */,
 				DD3A5AE71DE60A8D0016882D /* VideoModel.swift in Sources */,
 				1515D1191DDA9E34008690FD /* SpeakerDetailDescriptionCollectionViewCell.swift in Sources */,
+				DDABFB111DE72AEC00351DA8 /* UserDefaults+CHConf.swift in Sources */,
 				159164611DDD458800995EC2 /* TalkUnit.swift in Sources */,
 				15BBD8AF1DDA493400A9A45F /* SpeakerDetailHeaderUnit.swift in Sources */,
 				15DDF9351DD126CA00AD4B93 /* LocalDataFetcher.swift in Sources */,

--- a/CocoaheadsConf/Classes/Extensions/UserDefaults+CHConf.swift
+++ b/CocoaheadsConf/Classes/Extensions/UserDefaults+CHConf.swift
@@ -1,0 +1,29 @@
+//
+//  UserDefaults+CHConf.swift
+//  CocoaheadsConf
+//
+//  Created by Guilherme Rambo on 24/11/16.
+//  Copyright © 2016 Cocoaheads. All rights reserved.
+//
+
+import Foundation
+
+extension UserDefaults {
+    
+    private struct Keys {
+        static let positionSufix = "-position"
+        
+        static func position(in video: Int) -> String {
+            return "\(video)\(positionSufix)"
+        }
+    }
+    
+    func position(in video: Int) -> Float {
+        return UserDefaults.standard.float(forKey: Keys.position(in: video))
+    }
+    
+    func set(position: Float, in video: Int) {
+        UserDefaults.standard.setValue(position, forKey: Keys.position(in: video))
+    }
+    
+}

--- a/CocoaheadsConf/Classes/Scenes/Talks/TalkDetailUnits.swift
+++ b/CocoaheadsConf/Classes/Scenes/Talks/TalkDetailUnits.swift
@@ -55,8 +55,8 @@ struct TalkDetailUnits {
         return unit
     }
     
-    static func Play(playHandler: (() -> Void)?)-> ComposingUnit {
-        let unit = TalkDetailPlayVideoUnit(videoButtonCallback: playHandler)
+    static func Play(playHandler: (() -> Void)?, title: String)-> ComposingUnit {
+        let unit = TalkDetailPlayVideoUnit(videoButtonCallback: playHandler, buttonTitle: title)
         return unit
     }
     

--- a/CocoaheadsConf/Classes/Scenes/Talks/TalkDetailView.swift
+++ b/CocoaheadsConf/Classes/Scenes/Talks/TalkDetailView.swift
@@ -37,8 +37,16 @@ func ComposeTalkDetailView(with state: TalkDetailViewState, playVideoCallback: (
         let desc = TalkDetailUnits.Description(for: talk)
         return [header, desc]
     }
-    units.add(ifLet: talk.video) { _ in
-        return TalkDetailUnits.Play(playHandler: playVideoCallback)
+    units.add(ifLet: talk.video) { video in
+        let title: String
+        
+        if UserDefaults.standard.position(in: video.id) > 0 {
+            title = NSLocalizedString("Continuar Assistindo", comment: "Continue Watching - button title to continue watching a video")
+        } else {
+            title = NSLocalizedString("Assistir Vídeo", comment: "Watch Video - button title to start watching a video")
+        }
+        
+        return TalkDetailUnits.Play(playHandler: playVideoCallback, title: title)
     }
     units.add {
         let spacer = TalkDetailUnits.Spacer(with: "upperSpacer")

--- a/CocoaheadsConf/Classes/Scenes/Talks/TalkDetailViewController.swift
+++ b/CocoaheadsConf/Classes/Scenes/Talks/TalkDetailViewController.swift
@@ -32,7 +32,7 @@ class TalkDetailViewController: UIViewController {
         detailView?.didTapPlayCallback = { [unowned self] in
             guard let video = self.talkToShow.video else { return }
             
-            PlaybackHelper(with: video.youTubeUrl).play(from: self)
+            PlaybackHelper(with: video.youTubeUrl, id: video.id).play(from: self)
         }
     }
     

--- a/CocoaheadsConf/Classes/Scenes/Talks/Units/TalkDetailPlayVideoCollectionViewCell.swift
+++ b/CocoaheadsConf/Classes/Scenes/Talks/Units/TalkDetailPlayVideoCollectionViewCell.swift
@@ -21,6 +21,7 @@ class TalkDetailPlayVideoCollectionViewCell: UICollectionViewCell {
         spinner.startAnimating()
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             self.spinner.stopAnimating()
+            self.playButton.setTitle(NSLocalizedString("Continuar Assistindo", comment: "Continue Watching - button title to continue watching a video"), for: .normal)
             self.playButton.isHidden = false
         }
     }

--- a/CocoaheadsConf/Classes/Scenes/Talks/Units/TalkDetailPlayVideoUnit.swift
+++ b/CocoaheadsConf/Classes/Scenes/Talks/Units/TalkDetailPlayVideoUnit.swift
@@ -17,9 +17,11 @@ struct TalkDetailPlayVideoUnit : TypedUnit {
     let heightUnit: DimensionUnit = 38
     
     var videoButtonCallback: (() -> Void)?
+    var buttonTitle: String
     
     func configure(innerView: Cell) {
         innerView.videoButtonCallback = videoButtonCallback
+        innerView.playButton.setTitle(buttonTitle, for: .normal)
     }
     
     func reuseIdentifier() -> String {

--- a/CocoaheadsConf/Classes/Scenes/Videos/PlaybackHelper.swift
+++ b/CocoaheadsConf/Classes/Scenes/Videos/PlaybackHelper.swift
@@ -79,7 +79,6 @@ struct PlaybackHelper {
         player.addPeriodicTimeObserver(forInterval: CMTimeMakeWithSeconds(5, timeScale), queue: nil) { time in
             let position = Float(CMTimeGetSeconds(time))
             UserDefaults.standard.set(position: position, in: self.videoId)
-            NSLog("Time: \(position)")
         }
         
         controller.present(self.moviePlayer, animated: true) {

--- a/CocoaheadsConf/Classes/Scenes/Videos/PlaybackHelper.swift
+++ b/CocoaheadsConf/Classes/Scenes/Videos/PlaybackHelper.swift
@@ -18,9 +18,11 @@ struct PlaybackHelper {
     }
     
     let videoUrl: URL
+    let videoId: Int
     
-    init(with url: URL) {
+    init(with url: URL, id: Int) {
         self.videoUrl = url
+        self.videoId = id
     }
     
     private var moviePlayer: AVPlayerViewController = {
@@ -41,13 +43,10 @@ struct PlaybackHelper {
                 return
             }
             
-            if let videoURLString = info?["url"] as? String {
+            if let videoURLString = info?["url"] as? String,
+                let url = URL(string: videoURLString) {
                 DispatchQueue.main.async {
-                    let player = AVPlayer(url: URL(string: videoURLString)!)
-                    self.moviePlayer.player = player
-                    controller.present(self.moviePlayer, animated: true) {
-                        player.play()
-                    }
+                    self.setupAndPlay(url, from: controller)
                 }
             } else {
                 DispatchQueue.main.async {
@@ -68,6 +67,26 @@ struct PlaybackHelper {
         alert.addAction(action)
         
         controller.present(alert, animated: true, completion: nil)
+    }
+    
+    private func setupAndPlay(_ videoUrl: URL, from controller: UIViewController) {
+        let player = AVPlayer(url: videoUrl)
+        
+        self.moviePlayer.player = player
+        
+        let timeScale = Int32(NSEC_PER_SEC)
+        
+        player.addPeriodicTimeObserver(forInterval: CMTimeMakeWithSeconds(5, timeScale), queue: nil) { time in
+            let position = Float(CMTimeGetSeconds(time))
+            UserDefaults.standard.set(position: position, in: self.videoId)
+            NSLog("Time: \(position)")
+        }
+        
+        controller.present(self.moviePlayer, animated: true) {
+            let savedPosition = UserDefaults.standard.position(in: self.videoId)
+            player.seek(to: CMTimeMakeWithSeconds(Float64(savedPosition), timeScale))
+            player.play()
+        }
     }
     
 }


### PR DESCRIPTION
Ao assistir um vídeo, a posição é salva a cada 5s para que o usuário possa continuar assistindo de onde parou futuramente. O botão "Assistir Vídeo" muda para "Continuar Assistindo" quando há uma posição salva para o vídeo.

![simulator screen shot 24 nov 2016 12 34 35](https://cloud.githubusercontent.com/assets/67184/20602007/98d836e4-b242-11e6-8fcc-33cf51abae9a.png)

![simulator screen shot 24 nov 2016 12 34 31](https://cloud.githubusercontent.com/assets/67184/20602012/a09b1e28-b242-11e6-8d5b-23329553eed5.png)
