### PR TITLE
Arrumar a tab de horário

### DIFF
--- a/NSBrazilConf/ViewModels/FeedViewModel.swift
+++ b/NSBrazilConf/ViewModels/FeedViewModel.swift
@@ -27,7 +27,7 @@ public class FeedViewModel: ObservableObject {
             }, receiveValue: { value in
                 self.isLoading = false
                 self.homeFeed = value.feed.feedItems
-                self.scheduleFeed = value.feed.feedItems
+                self.scheduleFeed = value.schedule.feedItems
             })
     }
 


### PR DESCRIPTION
No último commit, o mapa de valores para a tab de horários ficou inválida. Isso arruma o mapper.