### PR TITLE
Abrir Apple Maps no Cubo

### DIFF
--- a/NSBrazilConf/Views/Home/Feed/MapFeedView.swift
+++ b/NSBrazilConf/Views/Home/Feed/MapFeedView.swift
@@ -18,18 +18,26 @@ struct MapFeedView: View, FeedViewProtocol {
    var feedItem: MapFeedItem
 
     var body: some View {
-        CardView{
-            VStack(alignment: HorizontalAlignment.leading) {
-                MapView(location: self.feedItem.location, annotationTitle: self.feedItem.title, span: self.feedItem.span)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("\(self.feedItem.title) \(self.feedItem.subtitle)")
-                        .font(.headline)
+        Button(action: self.openMap) {
+            CardView{
+                VStack(alignment: HorizontalAlignment.leading) {
+                    MapView(location: self.feedItem.location, annotationTitle: self.feedItem.title, span: self.feedItem.span)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("\(self.feedItem.title) \(self.feedItem.subtitle)")
+                            .font(.headline)
+                    }
+                    .padding(.leading, 16)
+                    .padding(.bottom, 8)
                 }
-                .padding(.leading, 16)
-                .padding(.bottom, 8)
             }
-        }
-        .frame(maxWidth: .infinity, minHeight: 286)
+        }.frame(maxWidth: .infinity, minHeight: 286)
+    }
+    
+    func openMap() {
+        let placemark = MKPlacemark(coordinate: self.feedItem.location)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = self.feedItem.title
+        mapItem.openInMaps(launchOptions: nil)
     }
 }
 


### PR DESCRIPTION
Esse código adiciona a possibilidade de abrir o Apple Maps e ver com mais detalhes onde é a conferência. Isso pode ser útil para quem está em direção ao evento, já que fica mais fácil para acompanhar onde tem de ir no mapa, em vez da versão minimizada.