### PR TITLE
Uso do LLVS para uma estratégia de cache

### DIFF
--- a/NSBrazilConf.xcodeproj/project.pbxproj
+++ b/NSBrazilConf.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -79,6 +79,8 @@
 		765CF5662367CDA2007B26D9 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D589C60234577CB003D95D8 /* Store.swift */; };
 		765CF5672367CDAC007B26D9 /* Bundle+NSBrazilConf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0A956C2342EB5A00B2C582 /* Bundle+NSBrazilConf.swift */; };
 		765CF5882367DE85007B26D9 /* NSBrazilData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765CF5872367DE85007B26D9 /* NSBrazilData.swift */; };
+		78EE5E4C23760031007D8FC0 /* LLVSCloudKit in Frameworks */ = {isa = PBXBuildFile; productRef = 78EE5E4B23760031007D8FC0 /* LLVSCloudKit */; };
+		78EE5E4E23760031007D8FC0 /* LLVS in Frameworks */ = {isa = PBXBuildFile; productRef = 78EE5E4D23760031007D8FC0 /* LLVS */; };
 		B40681AC236E430F00DE707D /* RetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40681AB236E430F00DE707D /* RetryView.swift */; };
 		B40AB56F237590E600752BD0 /* ActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40AB56E237590E600752BD0 /* ActivityIndicatorView.swift */; };
 		B4106ACC234A8E85007F0F74 /* FeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4106ACB234A8E85007F0F74 /* FeedItem.swift */; };
@@ -258,6 +260,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78EE5E4C23760031007D8FC0 /* LLVSCloudKit in Frameworks */,
+				78EE5E4E23760031007D8FC0 /* LLVS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -594,6 +598,10 @@
 			dependencies = (
 			);
 			name = NSBrazilConf;
+			packageProductDependencies = (
+				78EE5E4B23760031007D8FC0 /* LLVSCloudKit */,
+				78EE5E4D23760031007D8FC0 /* LLVS */,
+			);
 			productName = NSBrazilConf;
 			productReference = 1D0A95272342E87500B2C582 /* NSBrazil.app */;
 			productType = "com.apple.product-type.application";
@@ -682,6 +690,9 @@
 				Base,
 			);
 			mainGroup = 1D0A951E2342E87500B2C582;
+			packageReferences = (
+				78EE5E4A23760031007D8FC0 /* XCRemoteSwiftPackageReference "LLVS" */,
+			);
 			productRefGroup = 1D0A95282342E87500B2C582 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -990,6 +1001,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = NSBrazilConf/NSBrazilConf.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"NSBrazilConf/Preview Content\"";
@@ -1003,6 +1016,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.cocoaheads.CocoaheadsConf.NSBrazilConf;
 				PRODUCT_NAME = NSBrazil;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1014,6 +1029,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = NSBrazilConf/NSBrazilConf.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"NSBrazilConf/Preview Content\"";
@@ -1027,6 +1044,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.cocoaheads.CocoaheadsConf.NSBrazilConf;
 				PRODUCT_NAME = NSBrazil;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1200,6 +1219,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		78EE5E4A23760031007D8FC0 /* XCRemoteSwiftPackageReference "LLVS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mentalfaculty/LLVS.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78EE5E4B23760031007D8FC0 /* LLVSCloudKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 78EE5E4A23760031007D8FC0 /* XCRemoteSwiftPackageReference "LLVS" */;
+			productName = LLVSCloudKit;
+		};
+		78EE5E4D23760031007D8FC0 /* LLVS */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 78EE5E4A23760031007D8FC0 /* XCRemoteSwiftPackageReference "LLVS" */;
+			productName = LLVS;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 1D0A951F2342E87500B2C582 /* Project object */;
 }

--- a/NSBrazilConf.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/NSBrazilConf.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:NSBrazilConf.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/NSBrazilConf.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NSBrazilConf.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "LLVS",
+        "repositoryURL": "https://github.com/mentalfaculty/LLVS.git",
+        "state": {
+          "branch": null,
+          "revision": "3b21e21137d835fd1a4ab49589c0ea43272ed33b",
+          "version": "0.4.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/NSBrazilConf/Cache/Cache.swift
+++ b/NSBrazilConf/Cache/Cache.swift
@@ -7,56 +7,49 @@
 //
 
 import UIKit
+import LLVS
 
 class Cache: NSObject {
 
-    static let `default`: Cache = Cache()
+    private static let FeedValueId = Value.ID("HOME_FEED_CACHE")
     
-    var speakers: [Int:SpeakerModel] = [:]
-    var rooms: [Int:RoomModel] = [:]
-    var talks: [Int:TalkModel] = [:]
-    var sponsors: [SponsorModel] = []
-    var videos: [Int:VideoModel] = [:]
+    private lazy var cacheStore: LLVS.Store? = {
+        guard let rootDir = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first else {
+            return nil
+        }
+        let store = try? LLVS.Store(rootDirectoryURL: URL(fileURLWithPath: rootDir, isDirectory: true))
+        do {
+            try store?.reloadHistory()
+        } catch {
+            print("Failed to load cache history: \(error.localizedDescription)")
+        }
+        return store
+    }()
     
-    var event: FeedModel?
-    
-    func talk(with id: Int)-> TalkModel? {
-        return talks[id]
+    public func loadCache() -> Data? {
+        guard let store = self.cacheStore else {
+            return nil
+        }
+        
+        guard let version = store.mostRecentHead else {
+            return nil
+        }
+        
+        let value: Value? = try? store.value(id: Cache.FeedValueId, at: version.id)
+        return value?.data
     }
     
-    func talks(for speaker: SpeakerModel)-> [TalkModel]? {
-        return []
-    }
-    
-    func speaker(with id: Int)-> SpeakerModel? {
-        return speakers[id]
-    }
-    
-    func room(with id: Int)-> RoomModel? {
-        return rooms[id]
-    }
-    
-    func video(with id: Int) -> VideoModel? {
-        return videos[id]
-    }
-    
-    func video(for talk: Int) -> VideoModel? {
-        return videos.compactMap({ $0.1 }).filter({ $0.talk?.id == talk }).first
-    }
-    
-    func `import`(store: NSBrazilData) throws {
-//        let allSpeakers: [SpeakerModel] = try json.value(for: "speakers")
-//        allSpeakers.forEach { speakers[$0.id] = $0 }
-//        let allRooms: [RoomModel] = try json.value(for: "rooms")
-//        allRooms.forEach { rooms[$0.id] = $0 }
-//        let allTalks: [TalkModel] = try json.value(for: "talks")
-//        allTalks.forEach { talks[$0.id] = $0 }
-//        sponsors = try json.value(for: "sponsors")
-//        let allVideos: [VideoModel] = try json.value(for: "videos")
-//        allVideos.forEach({ videos[$0.id] = $0 })
-//        event = try json.value(for: "event")
-//        let theme: Theme = try json.value(for: "theme")
-//        Theme.shared.apply(theme: theme)
+    public func saveCache(_ data: Data) {
+        guard let store = self.cacheStore else {
+            return
+        }
+        
+        let value = Value(id: Cache.FeedValueId, data: data)
+        if let currentVersion = store.mostRecentHead {
+            let _ = try? store.makeVersion(basedOnPredecessor: currentVersion.id, storing: [.update(value)])
+        } else {
+            let _ = try? store.makeVersion(basedOnPredecessor: nil, storing: [.insert(value)])
+        }
     }
     
 }

--- a/NSBrazilConf/Models/VideoModel.swift
+++ b/NSBrazilConf/Models/VideoModel.swift
@@ -19,7 +19,7 @@ struct VideoModel: Codable, Identifiable {
     let youTubeUrl: URL
     
     var talk: TalkModel? {
-        return Cache.default.talk(with: talkId)
+        return nil
     }
     
 }

--- a/NSBrazilConf/Storage/NSBrazilStore.swift
+++ b/NSBrazilConf/Storage/NSBrazilStore.swift
@@ -5,7 +5,7 @@ import Combine
 public enum FetchError: Error {
     case parse(String)
     case unknown(Error)
-    case invalidCache
+    case invalidCache(Error)
 
     var localizedDescription: String {
         switch self {
@@ -13,8 +13,8 @@ public enum FetchError: Error {
             return String(format: NSLocalizedString("Unable to parse key %@ from json", comment: "Unable to parse fetch activity error"), key)
         case .unknown(let error):
             return String(format: NSLocalizedString("Unable to find info with identifier %@", comment: "info not found error"), error.localizedDescription)
-        case .invalidCache:
-            return String(format: NSLocalizedString("Unable to load device cache", comment: "info not found error"))
+        case .invalidCache(let error):
+            return String(format: NSLocalizedString("Unable to load device cache %@", comment: "info not found error"), error.localizedDescription)
         }
     }
 }
@@ -60,8 +60,8 @@ public final class NSBrazilStore: ObservableObject {
         
         return Just(self.cache.loadCache() ?? Data())
             .decode(type: HomeFeed.self, decoder: self.contentDecoder)
-            .mapError { _ in
-                return FetchError.invalidCache
+            .mapError { error in
+                return FetchError.invalidCache(error)
             }
             .eraseToAnyPublisher()
     }

--- a/NSBrazilConf/Storage/NSBrazilStore.swift
+++ b/NSBrazilConf/Storage/NSBrazilStore.swift
@@ -24,7 +24,7 @@ public final class NSBrazilStore: ObservableObject {
     private var cancellable: AnyCancellable?
     
     let cache: Cache = Cache()
-    public let session: URLSession = URLSession(configuration: URLSessionConfiguration.ephemeral)
+    public let session: URLSession = URLSession.shared
     let jsonURL: URL = URL(string: "https://nsbrazil.com/app/2019.json")!
 
     private lazy var contentDecoder: JSONDecoder = {

--- a/NSBrazilConf/ViewModels/FeedViewModel.swift
+++ b/NSBrazilConf/ViewModels/FeedViewModel.swift
@@ -6,26 +6,20 @@ import Combine
 public class FeedViewModel: ObservableObject {
 
     @ObservedObject var store = NSBrazilStore()
-    private var cacheCancellable: AnyCancellable? = nil
-    private var storeCancellable: AnyCancellable? = nil
+    private var cancellable: AnyCancellable? = nil
 
     public init() {
         fetchInfo()
     }
 
     func fetchInfo() {
-        self.cacheCancellable = self.perform(publisher: self.store.fetchCache()) { [weak self] in
-            guard let self = self else { return }
-            self.storeCancellable = self.perform(publisher: self.store.fetchInfo())
-        }
-    }
-    
-    @discardableResult
-    private func perform(publisher: AnyPublisher<HomeFeed, FetchError>, completion: (()->Void)? = nil) -> AnyCancellable {
-        if homeFeed.isEmpty {
-            self.isLoading = true
-        }
-        return publisher
+        self.isLoading = true
+        
+        let cachePublisher = self.store.fetchCache()
+        let networkPublisher = self.store.fetchInfo()
+        
+        self.cancellable?.cancel()
+        self.cancellable = networkPublisher.catch({ _ in cachePublisher})
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { received in
                 switch received {
@@ -33,19 +27,15 @@ public class FeedViewModel: ObservableObject {
                     print("sim")
                 case .failure(_):
                     print("nao")
-                    self.isEmpty = true
                 }
-                completion?()
             }, receiveValue: { value in
                 self.isLoading = false
                 self.homeFeed = value.feed.feedItems
                 self.scheduleFeed = value.schedule.feedItems
-                completion?()
             })
     }
 
     @Published var homeFeed: [FeedItem] = []
     @Published var scheduleFeed: [FeedItem] = []
-    @Published var isEmpty: Bool = false
     @Published var isLoading: Bool = false
 }


### PR DESCRIPTION
@loloop Essa é uma proposta de uso do [LLVS](https://github.com/mentalfaculty/LLVS) para fazer um cache local de dados. Nesse primeiro código, a ideia é usar o cache local como um fallback no caso de falha de internet. Eu ainda não removi o cache default do URLSession, mas, coloquei um novo Publisher (Cache) para ser o catcher do publisher de Network.