### PR TITLE
Cache local básico

### DIFF
--- a/NSBrazilConf/Cache/Cache.swift
+++ b/NSBrazilConf/Cache/Cache.swift
@@ -20,12 +20,6 @@ class Cache: NSObject {
         return fullPath
     }()
     
-    let fileManager: FileManager
-    
-    init(fileManager: FileManager = .default) {
-        self.fileManager = fileManager
-    }
-    
     public func loadCache() -> Data? {
         guard let cachePath = self.cachePath else {
             return nil

--- a/NSBrazilConf/Cache/Cache.swift
+++ b/NSBrazilConf/Cache/Cache.swift
@@ -10,53 +10,42 @@ import UIKit
 
 class Cache: NSObject {
 
-    static let `default`: Cache = Cache()
+    private static let CacheFileID = "FEED_DATA_CACHE"
+    private lazy var cachePath: URL? = {
+        guard let rootDir = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first else {
+            return nil
+        }
+        let basePath = URL(fileURLWithPath: rootDir, isDirectory: true)
+        let fullPath = basePath.appendingPathComponent(Cache.CacheFileID, isDirectory: false)
+        return fullPath
+    }()
     
-    var speakers: [Int:SpeakerModel] = [:]
-    var rooms: [Int:RoomModel] = [:]
-    var talks: [Int:TalkModel] = [:]
-    var sponsors: [SponsorModel] = []
-    var videos: [Int:VideoModel] = [:]
+    let fileManager: FileManager
     
-    var event: FeedModel?
-    
-    func talk(with id: Int)-> TalkModel? {
-        return talks[id]
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
     }
     
-    func talks(for speaker: SpeakerModel)-> [TalkModel]? {
-        return []
+    public func loadCache() -> Data? {
+        guard let cachePath = self.cachePath else {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: cachePath) else {
+            return nil
+        }
+        return Data(base64Encoded: data)
     }
     
-    func speaker(with id: Int)-> SpeakerModel? {
-        return speakers[id]
-    }
-    
-    func room(with id: Int)-> RoomModel? {
-        return rooms[id]
-    }
-    
-    func video(with id: Int) -> VideoModel? {
-        return videos[id]
-    }
-    
-    func video(for talk: Int) -> VideoModel? {
-        return videos.compactMap({ $0.1 }).filter({ $0.talk?.id == talk }).first
-    }
-    
-    func `import`(store: NSBrazilData) throws {
-//        let allSpeakers: [SpeakerModel] = try json.value(for: "speakers")
-//        allSpeakers.forEach { speakers[$0.id] = $0 }
-//        let allRooms: [RoomModel] = try json.value(for: "rooms")
-//        allRooms.forEach { rooms[$0.id] = $0 }
-//        let allTalks: [TalkModel] = try json.value(for: "talks")
-//        allTalks.forEach { talks[$0.id] = $0 }
-//        sponsors = try json.value(for: "sponsors")
-//        let allVideos: [VideoModel] = try json.value(for: "videos")
-//        allVideos.forEach({ videos[$0.id] = $0 })
-//        event = try json.value(for: "event")
-//        let theme: Theme = try json.value(for: "theme")
-//        Theme.shared.apply(theme: theme)
+    public func saveCache(_ data: Data) {
+        guard let cachePath = self.cachePath else {
+            return
+        }
+        let dataToStore = data.base64EncodedData()
+        do {
+            try dataToStore.write(to: cachePath, options: [.atomicWrite, .completeFileProtection])
+        } catch {
+            print("Error on storying cache: \(error.localizedDescription)")
+        }
     }
     
 }

--- a/NSBrazilConf/Models/VideoModel.swift
+++ b/NSBrazilConf/Models/VideoModel.swift
@@ -19,7 +19,7 @@ struct VideoModel: Codable, Identifiable {
     let youTubeUrl: URL
     
     var talk: TalkModel? {
-        return Cache.default.talk(with: talkId)
+        return nil
     }
     
 }

--- a/NSBrazilConf/Storage/NSBrazilStore.swift
+++ b/NSBrazilConf/Storage/NSBrazilStore.swift
@@ -1,10 +1,10 @@
-
 import SwiftUI
 import Combine
 
 public enum FetchError: Error {
     case parse(String)
     case unknown(Error)
+    case invalidCache(Error)
 
     var localizedDescription: String {
         switch self {
@@ -12,6 +12,8 @@ public enum FetchError: Error {
             return String(format: NSLocalizedString("Unable to parse key %@ from json", comment: "Unable to parse fetch activity error"), key)
         case .unknown(let error):
             return String(format: NSLocalizedString("Unable to find info with identifier %@", comment: "info not found error"), error.localizedDescription)
+        case .invalidCache(let error):
+            return String(format: NSLocalizedString("Unable to load device cache %@", comment: "info not found error"), error.localizedDescription)
         }
     }
 }
@@ -24,6 +26,12 @@ public final class NSBrazilStore: ObservableObject {
     public let session: URLSession = URLSession.shared
     let jsonURL: URL = URL(string: "https://nsbrazil.com/app/2019.json")!
 
+    private lazy var contentDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+    
     public var objectWillChange = ObservableObjectPublisher()
     
     public init() {}
@@ -32,20 +40,31 @@ public final class NSBrazilStore: ObservableObject {
     @Published var isLoading: Bool = true
 
     func decode(_ data: Data) -> AnyPublisher<NSBrazil.HomeFeed, FetchError> {
-      let decoder = JSONDecoder()
-      decoder.dateDecodingStrategy = .iso8601
 
-      return Just(data)
-        .decode(type: HomeFeed.self, decoder: decoder)
-        .mapError { error in
-          switch error {
-              case is DecodingError: return FetchError.parse(error.localizedDescription)
-              default: return FetchError.unknown(error)
-          }
-        }
-        .eraseToAnyPublisher()
+        return Just(data)
+            .decode(type: HomeFeed.self, decoder: self.contentDecoder)
+            .mapError { error in
+                switch error {
+                case is DecodingError: return FetchError.parse(error.localizedDescription)
+                default: return FetchError.unknown(error)
+                }
+            }.map {
+                self.cache.saveCache(data)
+                return $0
+            }
+            .eraseToAnyPublisher()
     }
-
+    
+    public func fetchCache() -> AnyPublisher<HomeFeed, FetchError> {
+        
+        return Just(self.cache.loadCache() ?? Data())
+            .decode(type: HomeFeed.self, decoder: self.contentDecoder)
+            .mapError { error in
+                return FetchError.invalidCache(error)
+            }
+            .eraseToAnyPublisher()
+    }
+    
     public func fetchInfo() -> AnyPublisher<HomeFeed, FetchError> {
         return session.dataTaskPublisher(for: jsonURL)
             .map { $0.data }
@@ -57,5 +76,3 @@ public final class NSBrazilStore: ObservableObject {
             }.eraseToAnyPublisher()
     }
 }
-
-

--- a/NSBrazilConf/Storage/NSBrazilStore.swift
+++ b/NSBrazilConf/Storage/NSBrazilStore.swift
@@ -43,16 +43,16 @@ public final class NSBrazilStore: ObservableObject {
 
         return Just(data)
             .decode(type: HomeFeed.self, decoder: self.contentDecoder)
-            .mapError { error in
+            .handleEvents(receiveCompletion: { (completion) in
+                if case .finished = completion {
+                    self.cache.saveCache(data)
+                }
+            }).mapError { error in
                 switch error {
                 case is DecodingError: return FetchError.parse(error.localizedDescription)
                 default: return FetchError.unknown(error)
                 }
-            }.map {
-                self.cache.saveCache(data)
-                return $0
-            }
-            .eraseToAnyPublisher()
+            }.eraseToAnyPublisher()
     }
     
     public func fetchCache() -> AnyPublisher<HomeFeed, FetchError> {

--- a/NSBrazilConf/ViewModels/FeedViewModel.swift
+++ b/NSBrazilConf/ViewModels/FeedViewModel.swift
@@ -13,8 +13,13 @@ public class FeedViewModel: ObservableObject {
     }
 
     func fetchInfo() {
-        isLoading = true
-        cancellable = store.fetchInfo()
+        self.isLoading = true
+        
+        let cachePublisher = self.store.fetchCache()
+        let networkPublisher = self.store.fetchInfo()
+        
+        self.cancellable?.cancel()
+        self.cancellable = networkPublisher.catch({ _ in cachePublisher})
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { received in
                 switch received {
@@ -22,7 +27,6 @@ public class FeedViewModel: ObservableObject {
                     print("sim")
                 case .failure(_):
                     print("nao")
-                    self.isEmpty = true
                 }
             }, receiveValue: { value in
                 self.isLoading = false
@@ -33,6 +37,5 @@ public class FeedViewModel: ObservableObject {
 
     @Published var homeFeed: [FeedItem] = []
     @Published var scheduleFeed: [FeedItem] = []
-    @Published var isEmpty: Bool = false
     @Published var isLoading: Bool = false
 }


### PR DESCRIPTION
Esse código cria um cache local simples. Cobre o primeiro item do issue #38: "Aplicar cache ao download do JSON do feed". Ainda não há uma estratégia de limpeza de cache, e o cache normal do URLSession ainda não foi removido.

Nessa estratégia:
- Tenta carregar da internet
- Se falhar, tenta carregar do cache da URLSession
- Se falhar, lê o valor cacheado no device.

Caso o carregamento pela internet (ou cache do URLSession) funcione, o arquivo local é sobrescrito.

Minha motivação para criar esse PR foi um momento onde tentei ler informações sobre o evento, e não consegui por falta de internet (sendo que eu já havia acessado a informação anteriormente).