### PR TITLE
Corrige o layout da tela de evento no iOS 26

### DIFF
--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.370",
+          "green" : "0.586",
+          "red" : "0.208"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Assets.xcassets/Button/toolbarItemColor.colorset/Contents.json
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Assets.xcassets/Button/toolbarItemColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x35",
+          "green" : "0x5A",
+          "red" : "0x03"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0xC7",
+          "red" : "0x0A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventDetail.swift
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventDetail.swift
@@ -106,16 +106,23 @@ struct EventDetail: View {
 }
 
 extension View {
+  @ViewBuilder
   fileprivate func toolbarStyle(scrollPosition: CGFloat) -> some View {
-    self
-      .font(.caption)
-      .foregroundStyle(Color.buttonBottomGradient)
-      .padding()
-      .background {
-        Circle()
-          .fill(.background)
-          .shadow(radius: scrollPosition < -100 ? 1 : 0)
-          .animation(.default, value: scrollPosition)
-      }
+    if #available(iOS 26.0, *) {
+      self
+        .font(.caption)
+        .foregroundStyle(Color.buttonBottomGradient)
+    } else {
+      self
+        .font(.caption)
+        .foregroundStyle(Color.buttonBottomGradient)
+        .padding()
+        .background {
+          Circle()
+            .fill(.background)
+            .shadow(radius: scrollPosition < -100 ? 1 : 0)
+            .animation(.default, value: scrollPosition)
+        }
+    }
   }
 }

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventDetail.swift
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventDetail.swift
@@ -111,7 +111,7 @@ extension View {
     if #available(iOS 26.0, *) {
       self
         .font(.caption)
-        .foregroundStyle(Color.buttonBottomGradient)
+        .foregroundStyle(Color(.toolbarItem))
     } else {
       self
         .font(.caption)

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventDetail.swift
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventDetail.swift
@@ -108,6 +108,18 @@ struct EventDetail: View {
 extension View {
   @ViewBuilder
   fileprivate func toolbarStyle(scrollPosition: CGFloat) -> some View {
+    #if os(visionOS)
+    self
+      .font(.caption)
+      .foregroundStyle(.white)
+      .padding()
+      .background {
+        Circle()
+          .fill(Color(.lightGray))
+          .shadow(radius: scrollPosition < -100 ? 1 : 0)
+          .animation(.default, value: scrollPosition)
+      }
+    #else
     if #available(iOS 26.0, *) {
       self
         .font(.caption)
@@ -124,5 +136,6 @@ extension View {
             .animation(.default, value: scrollPosition)
         }
     }
+    #endif
   }
 }

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventList.swift
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/EventList.swift
@@ -15,7 +15,7 @@ struct EventList: View {
   @State private var isPresented: Event?
 
   var body: some View {
-    VStack(alignment: .leading) {
+    VStack(alignment: .leading, spacing: 20) {
       if events.isEmpty {
         ContentUnavailableView(
           "Não encontramos eventos para este chapter",
@@ -30,6 +30,7 @@ struct EventList: View {
             Ticket(event: event)
           }
           .buttonStyle(.plain)
+          .buttonBorderShape(.roundedRectangle)
         }
       }
     }

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/TicketCard.swift
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Events/TicketCard.swift
@@ -21,6 +21,26 @@ struct TicketCard<Content: View>: View {
         .offset(y: -60)
     }
     .clipped()
+    .platformBackground()
+  }
+}
+
+extension View {
+  @ViewBuilder
+  fileprivate func platformBackground() -> some View{
+    #if os(visionOS)
+    self
+    .background {
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(Color(.lightGray))
+        .stroke(.black.opacity(0.1))
+        .shadow(color: .black.opacity(0.1), radius: 7, x: 0, y: 3)
+        .shadow(color: .black.opacity(0.09), radius: 13, x: 0, y: 13)
+        .shadow(color: .black.opacity(0.05), radius: 18, x: 0, y: 30)
+        .shadow(color: .black.opacity(0.01), radius: 21, x: 0, y: 54)
+    }
+    #else
+    self
     .background {
       RoundedRectangle(cornerRadius: 8, style: .continuous)
         .fill(Color(.systemBackground))
@@ -30,5 +50,6 @@ struct TicketCard<Content: View>: View {
         .shadow(color: .black.opacity(0.05), radius: 18, x: 0, y: 30)
         .shadow(color: .black.opacity(0.01), radius: 21, x: 0, y: 54)
     }
+    #endif
   }
 }

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Views/Card.swift
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Views/Card.swift
@@ -51,6 +51,14 @@ struct Card<Content: View>: View {
 extension View {
   @ViewBuilder
   fileprivate func ticketBackground() -> some View {
+    #if os(visionOS)
+    self
+      .background {
+        RoundedRectangle(cornerRadius: 20, style: .continuous)
+          .fill(Color(.lightGray))
+          .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 4)
+      }
+    #else
     if #available(iOS 26.0, *) {
       self
         .glassEffect(in: .rect(cornerRadius: 20, style: .continuous))
@@ -62,5 +70,6 @@ extension View {
             .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 4)
         }
     }
+    #endif
   }
 }

--- a/CocoaHeadsKit/Sources/CocoaHeadsKit/Views/Card.swift
+++ b/CocoaHeadsKit/Sources/CocoaHeadsKit/Views/Card.swift
@@ -25,11 +25,7 @@ struct Card<Content: View>: View {
     }
     .padding(contentInset.0, contentInset.1)
     .frame(maxWidth: .infinity)
-    .background {
-      RoundedRectangle(cornerRadius: 20, style: .continuous)
-        .fill(Color(.systemBackground))
-        .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 4)
-    }
+    .ticketBackground()
   }
 }
 
@@ -49,5 +45,22 @@ struct Card<Content: View>: View {
     Rectangle()
       .fill(.secondary)
       .ignoresSafeArea()
+  }
+}
+
+extension View {
+  @ViewBuilder
+  fileprivate func ticketBackground() -> some View {
+    if #available(iOS 26.0, *) {
+      self
+        .glassEffect(in: .rect(cornerRadius: 20, style: .continuous))
+    } else {
+      self
+        .background {
+          RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .fill(Color(.systemBackground))
+            .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 4)
+        }
+    }
   }
 }


### PR DESCRIPTION
Este PR remove o background e o padding dos ToolbarItems da tela de evento no iOS 26 a favor de manter o efeito do Liquid Glass, e também transforma o background dos cards da mesma tela em `glassEffect` para o 26.

|  <img width="513" height="979" alt="image" src="https://github.com/user-attachments/assets/c3501920-5e4a-480a-8986-1f1f565280f3" /> |  <img width="513" height="979" alt="image" src="https://github.com/user-attachments/assets/ff1324eb-c303-4483-a42c-896a7f57dd83" /> | <img width="513" height="979" alt="image" src="https://github.com/user-attachments/assets/be50b36d-367a-488a-99c1-01255be08dab" /> | 
| ----- | ----- | ----- |
